### PR TITLE
[FEAT] - adding api functionality example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.0", features = ["derive"] }
+clap = { version = "4.1", features = ["derive"] }
+futures = "0.3"
+reqwest = { version = "0.11", features = ["json"] }
+tokio = { version = "1.24", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,2 +1,3 @@
 pub mod api;
 pub mod slack;
+pub mod spotify;

--- a/src/adapters/spotify.rs
+++ b/src/adapters/spotify.rs
@@ -1,0 +1,3 @@
+pub mod client;
+pub mod helpers;
+pub mod models;

--- a/src/adapters/spotify/client.rs
+++ b/src/adapters/spotify/client.rs
@@ -1,0 +1,44 @@
+// use core::result::Result::Ok;
+use reqwest::StatusCode;
+use reqwest::header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+
+use crate::adapters::spotify::models::APIResponse;
+// use crate::adapters::spotify::helpers::print_tracks;
+
+#[tokio::main]
+pub async fn query(query: &String) -> Result<(), Box<dyn std::error::Error>> {
+    let auth_token = &String::from("BQAQRQfVlEOChnH8-KD3Y3nbl842lgx3rggdJ0Orb95i-4WrTdZy3JD8HF3V-O3cJqk5EQgrGEZg2S-fIL8HyfKZ738V8hoTr8m93NNBf_paHDF4hHAMSXJnNyM_s4ti4D9dUTVYW0aq9mof-L37Mi_lQRi_4pT05QcMIKaJZE716yU4ZW39lPghhSEcqO_OOmMH");
+    let url = format!(
+        "https://api.spotify.com/v1/search?q={query}&type=track,artist",
+        query = query
+    );
+    let client = reqwest::Client::new();
+    let response = client
+        .get(url)
+        .header(AUTHORIZATION, format!("Bearer {}", auth_token))
+        .header(CONTENT_TYPE, "application/json")
+        .header(ACCEPT, "application/json")
+        .send()
+        .await
+        .unwrap();
+    match response.status() {
+        StatusCode::OK => {
+            match response.json::<APIResponse>().await {
+                Ok(parsed) => println!("{:#?}", parsed),
+                Err(_) => panic!("Err caught on status OK...")
+            };
+        }
+        StatusCode::UNAUTHORIZED => {
+            println!("Need to grab a new token");
+        }
+        other => {
+            panic!("Uh oh! Something unexpected happened: {:?}", other);
+        }
+    };
+    // TODO: cleanup response
+    //       implement base client
+    //       add more commands and parameters
+    Ok(())
+}
+
+// TODO: discuss error variants https://rust-lang-nursery.github.io/rust-cookbook/errors/handle.html

--- a/src/adapters/spotify/client.rs
+++ b/src/adapters/spotify/client.rs
@@ -7,7 +7,7 @@ use crate::adapters::spotify::models::APIResponse;
 
 #[tokio::main]
 pub async fn query(query: &String) -> Result<(), Box<dyn std::error::Error>> {
-    let auth_token = &String::from("BQAQRQfVlEOChnH8-KD3Y3nbl842lgx3rggdJ0Orb95i-4WrTdZy3JD8HF3V-O3cJqk5EQgrGEZg2S-fIL8HyfKZ738V8hoTr8m93NNBf_paHDF4hHAMSXJnNyM_s4ti4D9dUTVYW0aq9mof-L37Mi_lQRi_4pT05QcMIKaJZE716yU4ZW39lPghhSEcqO_OOmMH");
+    let auth_token = &String::from("");
     let url = format!(
         "https://api.spotify.com/v1/search?q={query}&type=track,artist",
         query = query

--- a/src/adapters/spotify/helpers.rs
+++ b/src/adapters/spotify/helpers.rs
@@ -1,0 +1,19 @@
+use crate::adapters::spotify::models::Track;
+
+pub fn print_tracks(tracks: Vec<&Track>) {
+    for track in tracks {
+        println!("🔥 {}", track.name);
+        println!("💿 {}", track.album.name);
+        println!(
+            "🕺 {}",
+            track
+                .album
+                .artists
+                .iter()
+                .map(|artist| artist.name.to_string())
+                .collect::<String>()
+        );
+        println!("🌎 {}", track.external_urls.spotify);
+        println!("---------")
+    }
+}

--- a/src/adapters/spotify/models.rs
+++ b/src/adapters/spotify/models.rs
@@ -1,0 +1,38 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ExternalUrls {
+    pub spotify: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Artist {
+    pub name: String,
+    pub external_urls: ExternalUrls,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Album {
+    pub name: String,
+    pub artists: Vec<Artist>,
+    pub external_urls: ExternalUrls,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Track {
+    pub name: String,
+    pub href: String,
+    pub popularity: u32,
+    pub album: Album,
+    pub external_urls: ExternalUrls,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Items<T> {
+    pub items: Vec<T>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct APIResponse {
+    pub tracks: Items<Track>,
+}

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,1 +1,3 @@
+pub mod base;
 pub mod slack;
+pub mod spotify;

--- a/src/cli/commands/base.rs
+++ b/src/cli/commands/base.rs
@@ -1,0 +1,13 @@
+use ::clap::Subcommand;
+
+use crate::cli::commands::slack::SlackArgs;
+use crate::cli::commands::spotify::SpotifyArgs;
+
+// first tier subcommands - e.g. acbli slack or abcli evernote
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Command to interface with various methods from the Slack API
+    Slack(SlackArgs),
+    /// Command to interface with various methods from the Spotify API
+    Spotify(SpotifyArgs),
+}

--- a/src/cli/commands/spotify.rs
+++ b/src/cli/commands/spotify.rs
@@ -3,8 +3,8 @@ use ::clap::Args;
 
 #[derive(Args)]
 /// Returns Slack status for the given user
-pub struct SlackArgs {
+pub struct SpotifyArgs {
     /// For now - just returns the string in reverse
-    #[arg(short = 's', long = "string")]
-    pub string: Option<String>,
+    #[arg(short = 'q', long = "query")]
+    pub query: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#[allow(dead_code)]
+
 mod adapters;
 mod cli;
 
@@ -5,9 +7,11 @@ mod prelude {
     // add adapters
     pub use crate::adapters::api::client as api_client;
     pub use crate::adapters::slack::client as slack_client;
+    pub use crate::adapters::spotify::client as spotify_client;
     pub use crate::adapters::slack::stringer as slack_stringer;
+    pub use crate::adapters::spotify::helpers as spotify_hlprs;
     // add cli
-    pub use crate::cli::commands::slack::Commands;
+    pub use crate::cli::commands::base::Commands;
 }
 use crate::prelude::*;
 
@@ -38,7 +42,20 @@ fn main() {
                     println!("{}", reverse);
                 }
                 None => {
-                    println!("Please provide a string to reverse");
+                    println!("Please provide a string to reverse..");
+                }
+            }
+        }
+        Some(Commands::Spotify(args)) => {
+            // This is the args level (for now) - e.g. slack status or slack set
+            // args.string extracts the field value for the arg value "string"
+            match args.query {
+                Some(ref _args) => {
+                    let reverse = spotify_client::query(&_args);
+                    println!("{:#?}", reverse);
+                }
+                None => {
+                    println!("Please provide a query to search for...");
                 }
             }
         }


### PR DESCRIPTION
# What
Learning Rust is hard, but luckily there are plenty of resources out there. I took the implementation of reqwest from [here](https://blog.logrocket.com/making-http-requests-rust-reqwest/). The idea is to put in place a sample set of code to look at when evolving the CLI capabilities for Slack (and others). The tutorial in the link is really nice in explaining things and setting things up. 

# Changes
- [X] add Cargo.toml dependencies 
_had a weird thing. Two actually. I needed to add my ssh keys after adding a new GPG key. [This](https://github.com/rust-lang/cargo/issues/3381#issuecomment-308460530) solved it. And `cargo build` wouldn't run due to some cc issues. I ended up running `xcode-select --install` to fix it. This was likely due to upgrading my Mac to Ventura_
- [X] refactor the code base for commands to have a base command and inherit from slack/spotify
- [X] add the core of the functionality to call APIs - but only for Spotify client
- [X] refactor a bit main.rs to include the new commands
- [X] clean up after myself, I accidentally committed my API key (which I think is only valid for 60mins anyway)