### PR TITLE
[REFACTOR] - secure-store: making it easy to use

### DIFF
--- a/secure/secrets.dev.json
+++ b/secure/secrets.dev.json
@@ -16,6 +16,11 @@
       "iv": "V+vBdtN5XIWgBdIDuv1NGg==",
       "hmac": "mX2j3AYY3h2NprRPcym0Eu8GgFc=",
       "payload": "RvoND272Yq9nEhZ9X45KyA=="
+    },
+    "spotify:api_key": {
+      "iv": "puyJHEUOTN0j5FKGyk2t6A==",
+      "hmac": "CROYfFmvOhvPBzwpSeyCFvsS238=",
+      "payload": "b1ODwk2/lbv9Dwl2IP0kH139E4nSIPBfMIFrven62gOP0aoJtfGZnzf/gO0/OgWQlurY/FMSS4waIbU9U/k7DQ2ZgEPY0dD3l41wNB+fcEeqY9LjtEYoKCrwkCkFSSuIP8Bo2S7U7ulgzQ87bXE8PiwKrLEkG3aQ1y9zYsT9+6u8So78Ea2Vrj+dxRs8urW7GjDLoLCLwJfq9ESHS0xDlu4tvlKVTVq8QVZjMmD8NuEzmnd4/shD5J7huLkUzXLFAZ2uZcdTuLAZXiLoERrcvQ=="
     }
   }
 }

--- a/src/adapters/spotify/client.rs
+++ b/src/adapters/spotify/client.rs
@@ -1,16 +1,24 @@
-// use core::result::Result::Ok;
-use reqwest::header::{HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use reqwest::header::{
+    HeaderValue,
+    ACCEPT,
+    AUTHORIZATION,
+    CONTENT_TYPE
+};
 
 use crate::adapters::api::client::client;
 use crate::adapters::api::models::{Header, Headers};
 use crate::adapters::spotify::helpers::parse_response;
+use crate::app::secrets::get_secret;
 
 
-// TODO: finish
-fn set_auth() {}
+// TODO: finish | need to make this generic as well
+    // Add support for:
+    // Basic
+    // OAuth
+    // Bearer
 
 fn set_headers() -> Headers {
-    let fake_auth = "";
+    let api_key = get_secret("spotify:api_key");
     let headers = Headers {
         headers: vec![
             Header {
@@ -19,7 +27,7 @@ fn set_headers() -> Headers {
             },
             Header {
                 header_name: AUTHORIZATION,
-                header_value: HeaderValue::from_str(format!("Bearer {fake_auth}")
+                header_value: HeaderValue::from_str(format!("Bearer {api_key}")
                     .as_str())
                     .unwrap()
             },
@@ -40,5 +48,3 @@ pub async fn query(query: &String) {
 
     parse_response(response.await).await;
 }
-
-// TODO: discuss error variants https://rust-lang-nursery.github.io/rust-cookbook/errors/handle.html

--- a/src/app/secrets.rs
+++ b/src/app/secrets.rs
@@ -1,5 +1,5 @@
 use securestore::{KeySource, SecretsManager};
-use std::{path::Path, collections::HashMap};
+use std::path::Path;
 use once_cell::sync::Lazy;
 
 
@@ -15,11 +15,17 @@ pub static SECRETS: Lazy<SecretsManager> = Lazy::new(|| {
         .expect("Failed to load SecureStore vault!")
 });
 
-pub fn get_secret(secret_map: &mut HashMap<String, String>)
-    -> Result<HashMap<&String, String>, securestore::Error> {
-        let mut ret = HashMap::new();
-        for (k, _) in secret_map.iter_mut() {
-            ret.insert(k, SECRETS.get(k.as_str())?);
-        }
-    Ok(ret)
+pub fn get_secret(key: &str) -> std::string::String {
+    SECRETS.get(key).expect("Failed to retrieve secret")
 }
+
+// TODO: look into writing own type with implemented functions to retrieve map & value
+// Leaving this here for later
+// pub fn get_secret_map(secret_map: &mut HashMap<String, String>)
+//     -> Result<HashMap<&String, String>, securestore::Error> {
+//         let mut ret = HashMap::new();
+//         for (k, _) in secret_map.iter_mut() {
+//             ret.insert(k, SECRETS.get(k.as_str())?);
+//         }
+//     Ok(ret)
+// }


### PR DESCRIPTION
# What
Turns out I was trying to be too clever. Needed to simplify my implementation to just retrieve the secret needed at the time. This achieves that.

# Changes
- [X] return a single secret value on request
- [X] add Spotify api key to secret store for dev (it expires after 60mins to it's likely already useless)
- [X] retrieve the secret to be used in the Spotify query call