### PR TITLE
[CHORE] - support sub-subcommands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "4.1", features = ["derive"] }
+clap = { version = "4.1", features = ["derive", "env"] }
 color-eyre = "0.6.2"
 dotenv = { version = "0.15.0", features = ["clap", "cli"] }
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # abcli
 A Basic CLI, a.k.a. abcli - my first journey into Rust and I'm automating some silly things locally.
+
+// TODO - add proper content here next

--- a/src/adapters/notion/client.rs
+++ b/src/adapters/notion/client.rs
@@ -9,6 +9,7 @@ use crate::adapters::api::client;
 use crate::adapters::api::models::{Header, Headers};
 use crate::adapters::notion::helpers::parse_response;
 use crate::app::secrets::get_secret;
+use crate::prelude::notion::NotionArgs;
 
 use super::helpers::set_page_body;
 
@@ -37,10 +38,10 @@ fn set_headers() -> Headers {
     headers
 }
 
-pub async fn create(title: &String) {
+pub async fn create(args: NotionArgs) {
     let url = "https://api.notion.com/v1/pages/".to_string();
 
-    let data = set_page_body(title);
+    let data = set_page_body(args.page_title, args.database_id);
     let response = client::post(url, set_headers(), &data);
 
     parse_response(response.await).await

--- a/src/adapters/notion/helpers.rs
+++ b/src/adapters/notion/helpers.rs
@@ -5,6 +5,7 @@ use super::models::page;
 use super::models::properties;
 use super::models::shared;
 
+
 pub fn set_annontations() -> shared::Annotations {
     shared::Annotations {
         bold: false,
@@ -16,13 +17,11 @@ pub fn set_annontations() -> shared::Annotations {
     }
 }
 
-pub fn set_page_body(title: &String) -> page::Request {
-
-    let pt = title.to_owned();
+pub fn set_page_body(title: String, database_id: String) -> page::Request {
 
     let parent = shared::Parent::Database(shared::DatabaseParent {
         type_field: "database_id".to_string(),
-        database_id: std::env::var("NOTION_DATABASE_ID").is_ok().to_string()
+        database_id
     });
     let properties = properties::Properties {
         name: Some(properties::Name {
@@ -31,11 +30,11 @@ pub fn set_page_body(title: &String) -> page::Request {
             title: vec![shared::Title {
                 type_field: "text".to_string(),
                 text: shared::Text {
-                    content: pt.clone(),
+                    content: title.clone(),
                     link: None
                 },
                 annotations: Some(set_annontations()),
-                plain_text: pt,
+                plain_text: title,
                 href: None
             }]
         })
@@ -65,10 +64,9 @@ pub async fn parse_response(response: Response) {
 }
 
 pub fn parse_success(obj: page::Response) {
-    // let serialized_data = serde_json::to_string(obj).unwrap();
-    info!("Successfully created new page!\n");
+    info!("Successfully created new page(s)!");
 
     for title in obj.properties.name.unwrap().title {
-        info!("Title: {}\n", title.plain_text)
+        info!("Title: {}", title.plain_text)
     };
 }

--- a/src/cli/commands/base.rs
+++ b/src/cli/commands/base.rs
@@ -1,11 +1,65 @@
-use clap::Subcommand;
+use clap::{Subcommand, ValueEnum};
 
-use super::notion::NotionArgs;
+use super::notion::Notion;
 
 
-// first tier subcommands - e.g. acbli slack or abcli evernote
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 pub enum Commands {
-    /// Command to interface with various method from the Notion API
-    Notion(NotionArgs)
+    // /// Clones repos
+    // #[command(arg_required_else_help = true)]
+    // Clone {
+    //     /// The remote to clone
+    //     remote: String,
+    // },
+    // /// Compare two commits
+    // Diff {
+    //     #[arg(value_name = "COMMIT")]
+    //     base: Option<OsString>,
+    //     #[arg(value_name = "COMMIT")]
+    //     head: Option<OsString>,
+    //     #[arg(last = true)]
+    //     path: Option<OsString>,
+    //     #[arg(
+    //         long,
+    //         require_equals = true,
+    //         value_name = "WHEN",
+    //         num_args = 0..=1,
+    //         default_value_t = ColorWhen::Auto,
+    //         default_missing_value = "always",
+    //         value_enum
+    //     )]
+    //     color: ColorWhen,
+    // },
+    // /// pushes things
+    // #[command(arg_required_else_help = true)]
+    // Push {
+    //     /// The remote to target
+    //     remote: String,
+    // },
+    // /// adds things
+    // #[command(arg_required_else_help = true)]
+    // Add {
+    //     /// Stuff to add
+    //     #[arg(required = true)]
+    //     path: Vec<PathBuf>,
+    // },
+    Notion(Notion),
+    // #[command(external_subcommand)]
+    // External(Vec<OsString>),
+}
+
+#[derive(ValueEnum, Copy, Clone, Debug, PartialEq, Eq)]
+enum ColorWhen {
+    Always,
+    Auto,
+    Never,
+}
+
+impl std::fmt::Display for ColorWhen {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.to_possible_value()
+            .expect("no values are skipped")
+            .get_name()
+            .fmt(f)
+    }
 }

--- a/src/cli/commands/notion.rs
+++ b/src/cli/commands/notion.rs
@@ -2,19 +2,39 @@ use clap::Args;
 use clap::Subcommand;
 
 
-// TODO: Look into sub sub commands and how to do this
-#[derive(Subcommand)]
-/// Returns Slack status for the given user
-pub enum NotionCommands {
-    /// Subcommand for Notion to create objects
-    Create(NotionArgs)
+#[derive(Debug, Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct Notion {
+    #[command(subcommand)]
+    pub command: Option<NotionCommands>,
 }
 
-#[derive(Args)]
+#[derive(Debug, Subcommand)]
+pub enum NotionCommands {
+    Create(NotionSubcommands)
+}
+
+#[derive(Debug, Args)]
+#[command(args_conflicts_with_subcommands = true)]
+pub struct NotionSubcommands {
+    #[command(subcommand)]
+    pub command: Option<NotionSubCommands>
+}
+
+#[derive(Debug, Subcommand)]
+pub enum NotionSubCommands {
+    Page(NotionArgs)
+}
+
+#[derive(Debug, Args)]
 /// Returns Slack status for the given user
 pub struct NotionArgs {
     /// Title needed for the page to be created
     #[arg(short = 't', long = "title")]
     // for now this won't actually pass to the function to create the page
-    pub page_title: Option<String>,
+    pub page_title: String,
+
+    /// Database ID where the page object should be created.
+    #[arg(short = 'd', long = "database_id", env = "NOTION_DATABASE_ID")]
+    pub database_id: String
 }


### PR DESCRIPTION
# What
The CLI currently didn't support sub-subcommands and thus didn't truly function as intended. This fixes that by introducing a cleaned up derive-based CLI structure and adds support for additional args to be passed (only for create page). 

I had to read the docs a bit more carefully on using [magic attributes](https://docs.rs/clap/latest/clap/_derive/index.html#arg-attributes) and ended up finding `env` to derive default values from your environment variables. Clever little attribute ended up saving me about 4 lines of code. Nice find.

Other thing that came up - turns out I wasn't using my `dotenv` right. Filename should match `.env` exactly. Just a note for anyone seeing this issue too.

# Changes
- [X] add clap `env` cargo feature
- [X] big overhaul to support sub-subcommands and have it actually work E2E
- [X] notion client refactor to use the variables required a bit better