### PR TITLE
[FEATURE] - add page template support

### DIFF
--- a/src/adapters/notion/models/page.rs
+++ b/src/adapters/notion/models/page.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{properties::Properties, shared::{Parent, Children}};
+use super::{
+    properties::Properties,
+    shared::{Children, Parent},
+};
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/adapters/notion/models/page.rs
+++ b/src/adapters/notion/models/page.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use super::{properties::Properties, shared::Parent};
+use super::{properties::Properties, shared::{Parent, Children}};
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Request {
     pub parent: Parent,
     pub properties: Properties,
+    pub children: Vec<Children>,
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/adapters/notion/models/properties.rs
+++ b/src/adapters/notion/models/properties.rs
@@ -16,5 +16,5 @@ pub struct Name {
 #[serde(rename_all = "camelCase")]
 pub struct Properties {
     #[serde(rename = "Name")]
-    pub name: Option<Name>,
+    pub name: Name,
 }

--- a/src/adapters/notion/models/shared.rs
+++ b/src/adapters/notion/models/shared.rs
@@ -25,7 +25,7 @@ pub struct Title {
     #[serde(rename = "type")]
     pub type_field: String,
     pub text: Text,
-    #[serde(skip_serializing_if="Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<Annotations>,
     #[serde(rename = "plain_text")]
     pub plain_text: String,
@@ -87,7 +87,6 @@ pub struct RichText {
     pub type_field: String,
     pub text: Text,
 }
-
 
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/adapters/notion/models/shared.rs
+++ b/src/adapters/notion/models/shared.rs
@@ -25,18 +25,11 @@ pub struct Title {
     #[serde(rename = "type")]
     pub type_field: String,
     pub text: Text,
+    #[serde(skip_serializing_if="Option::is_none")]
     pub annotations: Option<Annotations>,
     #[serde(rename = "plain_text")]
     pub plain_text: String,
     pub href: Option<Value>,
-}
-
-#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RichText {
-    #[serde(rename = "rich_text")]
-    pub type_field: String,
-    pub text: Text,
 }
 
 /// Parent enum
@@ -67,4 +60,48 @@ pub struct DatabaseParent {
     pub type_field: String,
     #[serde(rename = "database_id")]
     pub database_id: String,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Children {
+    pub object: String,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    #[serde(rename = "heading_2")]
+    pub heading_2: Heading2,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Heading2 {
+    #[serde(rename = "rich_text")]
+    pub rich_text: Vec<RichText>,
+    pub children: Option<Vec<Option<BulletedListItem>>>,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RichText {
+    #[serde(rename = "type")]
+    pub type_field: String,
+    pub text: Text,
+}
+
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BulletedListItem {
+    pub object: String,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    #[serde(rename = "bulleted_list_item")]
+    pub bulleted_list_item: BulletedListRichText,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BulletedListRichText {
+    #[serde(rename = "rich_text")]
+    pub rich_text: Vec<RichText>,
 }

--- a/templates/notion/pages/daily.json
+++ b/templates/notion/pages/daily.json
@@ -1,0 +1,141 @@
+{
+  "parent": {
+      "type": "database_id",
+      "database_id": "var.database_id"
+  },
+  "properties": {
+      "Name": {
+          "id": "LKBS985",
+          "type": "title",
+          "title": [
+              {
+                  "type": "text",
+                  "text": {
+                      "content": "var.date_today",
+                      "link": null
+                  },
+                  "plain_text": "var.date_today",
+                  "href": null
+              }
+          ]
+      }
+  },
+  "children": [
+      {
+          "object": "block",
+          "type": "heading_2",
+          "heading_2": {
+              "rich_text": [
+                  {
+                      "type": "text",
+                      "text": {
+                          "content": "Yesterday",
+                          "link": null
+                      }
+                  }
+              ],
+              "children":[{
+                "object": "block",
+                "type": "bulleted_list_item",
+                "bulleted_list_item": {
+                  "rich_text": [{
+                    "type": "text",
+                    "text": {
+                      "content": "",
+                      "link": null
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+      },
+      {
+          "object": "block",
+          "type": "heading_2",
+          "heading_2": {
+              "rich_text": [
+                  {
+                      "type": "text",
+                      "text": {
+                          "content": "Today",
+                          "link": null
+                      }
+                  }
+              ],
+              "children":[{
+                "object": "block",
+                "type": "bulleted_list_item",
+                "bulleted_list_item": {
+                  "rich_text": [{
+                    "type": "text",
+                    "text": {
+                      "content": "",
+                      "link": null
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+      },
+      {
+          "object": "block",
+          "type": "heading_2",
+          "heading_2": {
+              "rich_text": [
+                  {
+                      "type": "text",
+                      "text": {
+                          "content": "Blockers",
+                          "link": null
+                      }
+                  }
+              ],
+              "children":[{
+                "object": "block",
+                "type": "bulleted_list_item",
+                "bulleted_list_item": {
+                  "rich_text": [{
+                    "type": "text",
+                    "text": {
+                      "content": "",
+                      "link": null
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+      },
+      {
+          "object": "block",
+          "type": "heading_2",
+          "heading_2": {
+              "rich_text": [
+                  {
+                      "type": "text",
+                      "text": {
+                          "content": "Meetings",
+                          "link": null
+                      }
+                  }
+              ],
+              "children":[{
+                "object": "block",
+                "type": "bulleted_list_item",
+                "bulleted_list_item": {
+                  "rich_text": [{
+                    "type": "text",
+                    "text": {
+                      "content": "",
+                      "link": null
+                    }
+                  }]
+                }
+              }
+            ]
+          }
+      }
+  ]
+}


### PR DESCRIPTION
# What
Ok so I call this page template support but really it's just a way to specify the JSON body to be used when creating the specified page. What I like about this is I can use the JSON body in Postman to test and if it works there, paste it directly into a json file in the repo and make sure I ref it correctly. And boom. Easy win. This is also the second to last step to finally installing this as a crontab command to automate creating my pages in Notion in the morning. Seems trivial but it's a cool win to me. 

# Changes
- add some more models needed to support part of the template body I want
- clean up the way the body is set during client invocation
- add json payload for page "template"

Note to self: add precommit hooks locally. 